### PR TITLE
Fix broken alias_method

### DIFF
--- a/lib/dhash-vips.rb
+++ b/lib/dhash-vips.rb
@@ -34,7 +34,9 @@ module DHashVips
     begin
       require_relative "../idhash.#{Gem::Platform.local.os == "darwin" ? "bundle" : "o"}"
     rescue LoadError
-      alias_method :distance3, :distance3_ruby
+      def self.distance3(a, b)
+        distance3_ruby(a, b)
+      end
     else
       # we can't just do `defined? Bignum` because it's defined but deprecated (some internal CONST_DEPRECATED flag)
       if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.4")


### PR DESCRIPTION
In https://github.com/Nakilon/dhash-vips/commit/e0d1d8a64f1d52ed18e075b1d4059c0e86c275ef `extend self` was replaced with explicit `self.` methods.

Before:
https://github.com/Nakilon/dhash-vips/blob/5810193b38a5f4d99b6ec2984f974f87926b616b/lib/dhash-vips.rb#L33

After:
https://github.com/Nakilon/dhash-vips/blob/e0d1d8a64f1d52ed18e075b1d4059c0e86c275ef/lib/dhash-vips.rb#L31

So, `alias_method` stop working:
```
# bin/rails c
/usr/local/rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/dhash-vips-0.2.0.0/lib/dhash-vips.rb:37:in `rescue in <module:IDHash>': undefined method `distance3_ruby' for module `DHashVips::IDHash' (NameError)
        from /usr/local/rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/dhash-vips-0.2.0.0/lib/dhash-vips.rb:34:in `<module:IDHash>'
```

This is the most trivial fix (I don't want to use `define_singleton_method` to keep it simple).