### PR TITLE
Don't run post_install_test by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ end
 
 * To run unit tests in current env
 
-      $ ruby extconf.rb && make clean && make   # otherwise you might get silenced LoadError due to switching between rubies
+      $ ruby extconf.rb && make clean && make post_install_test  # otherwise you might get silenced LoadError due to switching between rubies
       $ bundle exec ruby test.rb && bundle exec ruby test_LoadError.rb
 
 * To run unit tests under all available latest major rbenv ruby versions

--- a/extconf.rb
+++ b/extconf.rb
@@ -8,9 +8,9 @@ unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.3.8")
   # Why this hack?
   # 1. Because I want to use Ruby and ./idhash.bundle for tests, not C.
   # 2. Because I don't want to bother users with two gems instead of one.
-  File.write "Makefile", <<~HEREDOC + File.read("Makefile")
-    .PHONY: test
-    test: all
+  File.write "Makefile", File.read("Makefile") + <<~HEREDOC
+    .PHONY: post_install_test
+    post_install_test: all
     \t$(RUBY) -r./lib/dhash-vips.rb ./lib/dhash-vips-post-install-test.rb
   HEREDOC
 end


### PR DESCRIPTION
I'm attempting to upgrade to ruby 4 in one of my apps that uses dhash-vips. I ended up seeing an error from this gem:

```
Gem::Specification#activate_dependencies': Could not find 'ffi' (~> 1.12) among
339 total gem(s) (Gem::MissingSpecError)

...

make: *** [Makefile:3: test] Error 1
make failed, exit code 2

...

An error occurred while installing dhash-vips (0.2.4.0), and Bundler cannot
continue.
In Gemfile:
  dhash-vips
```


`extconf.rb` prepends a `test:all` target to the Makefile, which makes `test` the default make target. This was causing issues in the parallel install of our dependency image because `ffi` wasn't resolvable when `dhash-vips` built, so `make test` failed and aborted the install.

My fix for this was switching to append this target to the makefile, and renaming it, so it's not the default and won't be run on bundle install. I also updated the README to use `make post_install_test` instead of just `make`